### PR TITLE
feat: add state memory to DDPG

### DIFF
--- a/lib/boat_learner/environments/double_tack_discrete.ex
+++ b/lib/boat_learner/environments/double_tack_discrete.ex
@@ -248,8 +248,6 @@ defmodule BoatLearner.Environments.DoubleTackDiscrete do
     penalized_speed_steps =
       Nx.select(tacking_mask, speed_penalty_multiplier * speed_steps, speed_steps)
 
-    has_tacked = Nx.any(tacking_mask)
-
     tack_count = env.tack_count + Nx.any(tacking_mask)
 
     # Calculate the position changes in x and y directions for each interval
@@ -354,14 +352,9 @@ defmodule BoatLearner.Environments.DoubleTackDiscrete do
 
   defnp calculate_reward(env) do
     %__MODULE__{
-      is_terminal: is_terminal,
       vmg: vmg,
       remaining_seconds: remaining_seconds,
-      max_remaining_seconds: max_remaining_seconds,
-      target_y: target_y,
-      y: y,
-      x: x,
-      heading: heading
+      max_remaining_seconds: max_remaining_seconds
     } = env
 
     has_reached_target = has_reached_target(env)

--- a/lib/boat_learner/environments/single_tack.ex
+++ b/lib/boat_learner/environments/single_tack.ex
@@ -271,8 +271,7 @@ defmodule BoatLearner.Environments.SingleTack do
       y: y,
       remaining_iterations: remaining_iterations,
       tack_count: tack_count,
-      target_y: target_y,
-      vmg: vmg
+      target_y: target_y
     } = env
 
     is_terminal =

--- a/lib/reinforcement_learning/agents/ddpg.ex
+++ b/lib/reinforcement_learning/agents/ddpg.ex
@@ -612,20 +612,20 @@ defmodule ReinforcementLearning.Agents.DDPG do
       else
         next_state_batch =
           [
-          state_batch,
-          next_state_batch
-        ]
-        |> Nx.concatenate(axis: 1)
-        |> Nx.slice_along_axis(1, num_states, axis: 1)
+            state_batch,
+            next_state_batch
+          ]
+          |> Nx.concatenate(axis: 1)
+          |> Nx.slice_along_axis(1, num_states, axis: 1)
 
         expected_shape = {batch_len, num_states, state_features_size}
-         actual_shape = Nx.shape(next_state_batch)
+        actual_shape = Nx.shape(next_state_batch)
 
-      if actual_shape != expected_shape do
-        raise "incorrect size for next_state_batch, expected #{inspect(expected_shape)}, got: #{actual_shape}"
-      end
+        if actual_shape != expected_shape do
+          raise "incorrect size for next_state_batch, expected #{inspect(expected_shape)}, got: #{actual_shape}"
+        end
 
-      next_state_batch
+        next_state_batch
       end
 
     non_final_mask = not is_terminal_batch

--- a/lib/reinforcement_learning/agents/ddpg.ex
+++ b/lib/reinforcement_learning/agents/ddpg.ex
@@ -10,6 +10,7 @@ defmodule ReinforcementLearning.Agents.DDPG do
   import Nx.Defn
 
   alias ReinforcementLearning.Utils.Noise.OUProcess
+  alias ReinforcementLearning.Utils.CircularBuffer
 
   @behaviour ReinforcementLearning.Agent
 
@@ -30,8 +31,6 @@ defmodule ReinforcementLearning.Agents.DDPG do
              :critic_params,
              :critic_target_params,
              :experience_replay_buffer,
-             :experience_replay_buffer_index,
-             :persisted_experience_replay_buffer_entries,
              :target_update_frequency,
              :loss,
              :loss_denominator,
@@ -54,7 +53,6 @@ defmodule ReinforcementLearning.Agents.DDPG do
            ],
            keep: [
              :environment_to_state_vector_fn,
-             :experience_replay_buffer_max_size,
              :actor_predict_fn,
              :critic_predict_fn,
              :state_vector_size,
@@ -77,11 +75,8 @@ defmodule ReinforcementLearning.Agents.DDPG do
     :actor_predict_fn,
     :critic_predict_fn,
     :experience_replay_buffer,
-    :experience_replay_buffer_index,
-    :persisted_experience_replay_buffer_entries,
     :environment_to_state_vector_fn,
     :gamma,
-    :experience_replay_buffer_max_size,
     :tau,
     :batch_size,
     :training_frequency,
@@ -115,8 +110,6 @@ defmodule ReinforcementLearning.Agents.DDPG do
       :critic_target_params,
       :critic_net,
       :experience_replay_buffer,
-      :experience_replay_buffer_index,
-      :persisted_experience_replay_buffer_entries,
       :environment_to_state_vector_fn,
       :performance_memory,
       :state_vector_to_input_fn,
@@ -298,19 +291,12 @@ defmodule ReinforcementLearning.Agents.DDPG do
       critic_predict_fn: critic_predict_fn,
       performance_threshold: opts[:performance_threshold],
       performance_memory:
-        opts[:performance_memory] ||
-          Nx.broadcast(total_reward, {opts[:performance_memory_length]}),
-      experience_replay_buffer_max_size: experience_replay_buffer_max_size,
+        opts[:performance_memory] || CircularBuffer.new({opts[:performance_memory_length]}),
       experience_replay_buffer:
         opts[:experience_replay_buffer] ||
-          Nx.broadcast(
-            Nx.tensor(0, type: :f32),
+          CircularBuffer.new(
             {experience_replay_buffer_max_size, 2 * state_vector_size + num_actions + 3}
           ),
-      experience_replay_buffer_index:
-        opts[:experience_replay_buffer_index] || Nx.tensor(0, type: :s64),
-      persisted_experience_replay_buffer_entries:
-        opts[:persisted_experience_replay_buffer_entries] || Nx.tensor(0, type: :s64),
       environment_to_state_vector_fn: environment_to_state_vector_fn,
       gamma: opts[:gamma],
       tau: opts[:tau],
@@ -366,55 +352,36 @@ defmodule ReinforcementLearning.Agents.DDPG do
           episode,
           %__MODULE__{
             exploration_warmup_episodes: exploration_warmup_episodes,
-            persisted_experience_replay_buffer_entries:
-              persisted_experience_replay_buffer_entries,
+            experience_replay_buffer: experience_replay_buffer,
             ou_process: ou_process,
             exploration_decay_rate: exploration_decay_rate,
             exploration_increase_rate: exploration_increase_rate,
             min_sigma: min_sigma,
             max_sigma: max_sigma,
             total_reward: reward,
-            performance_memory: %Nx.Tensor{shape: {n}} = performance_memory,
+            performance_memory: performance_memory,
             performance_threshold: performance_threshold
           } = state
         ) do
+    n = Nx.axis_size(performance_memory.data, 0)
+
     {ou_process, performance_memory} =
       cond do
         episode == 0 ->
           {ou_process, performance_memory}
 
-        episode < n or persisted_experience_replay_buffer_entries < n or
+        episode < n or experience_replay_buffer.size < n or
             episode < exploration_warmup_episodes ->
-          index = Nx.remainder(episode, n)
-
-          performance_memory =
-            Nx.indexed_put(
-              performance_memory,
-              Nx.reshape(index, {1, 1}),
-              Nx.reshape(reward, {1})
-            )
-
-          {ou_process, performance_memory}
+          {ou_process, CircularBuffer.append(performance_memory, reward)}
 
         true ->
-          index = Nx.remainder(episode, n)
-
-          performance_memory =
-            Nx.indexed_put(performance_memory, Nx.reshape(index, {1, 1}), Nx.reshape(reward, {1}))
-
-          index = Nx.remainder(index + 1, n)
-
-          # We want to get our 2 windows in sequence so that we can compare them.
-          # The rem(iota + index + 1, n) operation will effectively set it so that
-          # we have the oldest window starting at the first position, and then all elements
-          # in the circular buffer fall into sequence
-          window_indices = Nx.remainder(Nx.iota({n}) + index, n)
+          performance_memory = CircularBuffer.append(performance_memory, reward)
 
           # After we take and reshape, the first row contains the oldest `n//2` samples
           # and the second row, the remaining newest samples.
           windows =
             performance_memory
-            |> Nx.take(window_indices)
+            |> CircularBuffer.ordered_data()
             |> Nx.reshape({2, :auto})
 
           # avg[0]: avg of the previous performance window
@@ -490,6 +457,7 @@ defmodule ReinforcementLearning.Agents.DDPG do
              critic_predict_fn: critic_predict_fn,
              state_vector: state_vector,
              environment_to_state_vector_fn: as_state_vector_fn,
+             experience_replay_buffer: experience_replay_buffer,
              gamma: gamma
            }
          },
@@ -500,12 +468,6 @@ defmodule ReinforcementLearning.Agents.DDPG do
        ) do
     next_state_vector = as_state_vector_fn.(next_env_state)
 
-    idx = Nx.stack([state.agent_state.experience_replay_buffer_index, 0]) |> Nx.new_axis(0)
-
-    shape = {2 * Nx.size(state_vector) + Nx.size(action_vector) + 3, 1}
-
-    index_template = Nx.concatenate([Nx.broadcast(0, shape), Nx.iota(shape, axis: 0)], axis: 1)
-
     target_action_vector = actor_predict_fn.(actor_target_params, next_state_vector)
 
     target_prediction =
@@ -515,7 +477,7 @@ defmodule ReinforcementLearning.Agents.DDPG do
       reward + gamma * target_prediction * (1 - is_terminal) -
         critic_predict_fn.(critic_params, state_vector, action_vector)
 
-    temporal_difference = temporal_difference |> Nx.abs() |> Nx.reshape({1})
+    temporal_difference = Nx.abs(temporal_difference)
 
     updates =
       Nx.concatenate([
@@ -524,35 +486,17 @@ defmodule ReinforcementLearning.Agents.DDPG do
         Nx.new_axis(reward, 0),
         Nx.new_axis(is_terminal, 0),
         Nx.flatten(next_state_vector),
-        temporal_difference
+        Nx.reshape(temporal_difference, {1})
       ])
 
     experience_replay_buffer =
-      Nx.indexed_put(state.agent_state.experience_replay_buffer, idx + index_template, updates)
-
-    experience_replay_buffer_index =
-      Nx.remainder(
-        state.agent_state.experience_replay_buffer_index + 1,
-        state.agent_state.experience_replay_buffer_max_size
-      )
-
-    entries = state.agent_state.persisted_experience_replay_buffer_entries
-
-    persisted_experience_replay_buffer_entries =
-      Nx.select(
-        entries < state.agent_state.experience_replay_buffer_max_size,
-        entries + 1,
-        entries
-      )
+      CircularBuffer.append(experience_replay_buffer, updates)
 
     %{
       state
       | agent_state: %{
           state.agent_state
           | experience_replay_buffer: experience_replay_buffer,
-            experience_replay_buffer_index: experience_replay_buffer_index,
-            persisted_experience_replay_buffer_entries:
-              persisted_experience_replay_buffer_entries,
             total_reward: state.agent_state.total_reward + reward
         }
     }
@@ -561,19 +505,18 @@ defmodule ReinforcementLearning.Agents.DDPG do
   @impl true
   defn optimize_model(state) do
     %{
-      persisted_experience_replay_buffer_entries: persisted_experience_replay_buffer_entries,
-      experience_replay_buffer_index: experience_replay_buffer_index,
+      experience_replay_buffer: experience_replay_buffer,
       batch_size: batch_size,
       training_frequency: training_frequency,
       exploration_warmup_episodes: exploration_warmup_episodes
     } = state.agent_state
 
     warming_up = state.episode < exploration_warmup_episodes
-    has_at_least_one_batch = persisted_experience_replay_buffer_entries > batch_size
+    has_at_least_one_batch = experience_replay_buffer.size > batch_size
 
     should_train =
       not warming_up and has_at_least_one_batch and
-        rem(experience_replay_buffer_index, training_frequency) == 0
+        rem(experience_replay_buffer.index, training_frequency) == 0
 
     if should_train do
       train_loop(state, training_frequency)
@@ -654,7 +597,6 @@ defmodule ReinforcementLearning.Agents.DDPG do
             update_priorities(
               experience_replay_buffer,
               batch_idx,
-              state_vector_size * 2 + num_actions + 2,
               td_errors
             ),
             Nx.mean(td_errors ** 2)
@@ -739,28 +681,13 @@ defmodule ReinforcementLearning.Agents.DDPG do
           %{
             batch_size: batch_size,
             state_vector_size: state_vector_size,
-            num_actions: num_actions,
-            experience_replay_buffer_max_size: experience_replay_buffer_max_size
+            num_actions: num_actions
           } = agent_state
         ) do
-    %{shape: shape} = exp_replay_buffer = agent_state.experience_replay_buffer
-
-    case shape do
-      {^experience_replay_buffer_max_size, _} ->
-        :ok
-
-      shape ->
-        raise "expected shape {#{experience_replay_buffer_max_size}, _}, got: #{inspect(shape)}"
-    end
-
-    # Temporal Difference prioritizing:
-    # We are going to sort experiences by temporal difference
-    # and divide our buffer into 4 slices, from which we will
-    # then uniformily sample.
-    # The temporal difference is already stored in the end of our buffer.
+    data = agent_state.experience_replay_buffer.data
 
     temporal_difference =
-      exp_replay_buffer
+      data
       |> Nx.slice_along_axis(state_vector_size * 2 + num_actions + 2, 1, axis: 1)
       |> Nx.flatten()
 
@@ -768,31 +695,26 @@ defmodule ReinforcementLearning.Agents.DDPG do
     probs = priorities / Nx.sum(priorities)
 
     {batch_idx, random_key} =
-      random_key
-      |> Nx.Random.choice(Nx.iota(temporal_difference.shape), probs,
+      Nx.Random.choice(random_key, Nx.iota(temporal_difference.shape), probs,
         samples: batch_size,
         replace: false,
         axis: 0
       )
 
-    batch = Nx.take(exp_replay_buffer, batch_idx)
+    batch = Nx.take(data, batch_idx)
 
     {batch, batch_idx, random_key}
   end
 
-  defn update_priorities(
-         buffer,
-         %{shape: {n}} = row_idx,
-         target_column,
-         td_errors
-       ) do
+  defn update_priorities(%{data: %{shape: {_, item_size}}} = buffer, %{shape: {n}} = entry_indices, td_errors) do
     case td_errors.shape do
       {^n, 1} -> :ok
       shape -> raise "invalid shape for td_errors, got: #{inspect(shape)}"
     end
 
-    indices = Nx.stack([row_idx, Nx.broadcast(target_column, {n})], axis: -1)
+    indices =
+      Nx.stack([entry_indices, Nx.broadcast(item_size - 1, {n})], axis: -1)
 
-    Nx.indexed_put(buffer, indices, Nx.reshape(td_errors, {n}))
+    %{buffer | data: Nx.indexed_put(buffer.data, indices, Nx.reshape(td_errors, {n}))}
   end
 end

--- a/lib/reinforcement_learning/agents/dqn.ex
+++ b/lib/reinforcement_learning/agents/dqn.ex
@@ -10,6 +10,7 @@ defmodule ReinforcementLearning.Agents.DQN do
 
   @eps_start 1
   @eps_decay_rate 0.995
+  @eps_increase_rate 1.005
   @eps_end 0.01
 
   @train_every_steps 32

--- a/lib/reinforcement_learning/reinforcement_learning.ex
+++ b/lib/reinforcement_learning/reinforcement_learning.ex
@@ -55,14 +55,15 @@ defmodule ReinforcementLearning do
     {init_agent_state, random_key} = agent.init(random_key, agent_init_opts)
     episode = Nx.tensor(opts[:accumulated_episodes], type: :s64)
 
+    {environment_state, random_key} = environment.init(random_key, environment_init_opts)
+
     {agent_state, random_key} =
       agent.reset(random_key, %__MODULE__{
+        environment_state: environment_state,
         agent: agent,
         agent_state: init_agent_state,
         episode: episode
       })
-
-    {environment_state, random_key} = environment.init(random_key, environment_init_opts)
 
     initial_state = %__MODULE__{
       agent: agent,
@@ -137,9 +138,10 @@ defmodule ReinforcementLearning do
          environment,
          state_to_trajectory_fn
        ) do
-    {agent_state, random_key} = agent.reset(random_key, loop_state)
-
     {environment_state, random_key} = environment.reset(random_key, environment_state)
+
+    {agent_state, random_key} =
+      agent.reset(random_key, %{loop_state | environment_state: environment_state})
 
     state = %{
       loop_state

--- a/lib/reinforcement_learning/utils/circular_buffer.ex
+++ b/lib/reinforcement_learning/utils/circular_buffer.ex
@@ -1,0 +1,48 @@
+defmodule ReinforcementLearning.Utils.CircularBuffer do
+  @moduledoc """
+  Circular Buffer utility via Nx Containers.
+  """
+
+  import Nx.Defn
+
+  @derive {Nx.Container, containers: [:data, :index, :size], keep: []}
+  defstruct [:data, :index, :size]
+
+  def new(shape, opts \\ [init_value: 0, type: :f32]) do
+    %__MODULE__{
+      data: Nx.broadcast(Nx.tensor(opts[:init_value], type: opts[:type]), shape),
+      size: 0,
+      index: 0
+    }
+  end
+
+  defn append(buffer, item) do
+    starts = append_start_indices(buffer)
+    n = Nx.axis_size(buffer.data, 0)
+    index = Nx.remainder(buffer.index + 1, n)
+    size = Nx.min(n, buffer.size + 1)
+
+    %{
+      buffer
+      | data: Nx.put_slice(buffer.data, starts, Nx.new_axis(item, 0)),
+        size: size,
+        index: index
+    }
+  end
+
+  deftransformp append_start_indices(buffer) do
+    [buffer.index | List.duplicate(0, tuple_size(buffer.data.shape) - 1)]
+  end
+
+  @doc """
+  Returns the data starting at the current index.
+
+  The oldest persisted entry will be the first entry in
+  the result, and so on.
+  """
+  defn ordered_data(buffer) do
+    n = elem(buffer.data.shape, 0)
+    indices = Nx.remainder(Nx.iota({n}) + buffer.index, n)
+    Nx.take(buffer.data, indices)
+  end
+end

--- a/livebooks/double_tack.livemd
+++ b/livebooks/double_tack.livemd
@@ -9,9 +9,9 @@ Mix.install(
   ],
   config_path: Path.join(my_app_root, "config/config.exs"),
   lockfile: Path.join(my_app_root, "mix.lock"),
-  consolidate_protocols: false,
+  consolidate_protocols: false
   # change to "cuda118" to use CUDA
-  system_env: %{"XLA_TARGET" => "cuda118"}
+  # system_env: %{"XLA_TARGET" => "cuda118"}
   # force: true
 )
 ```
@@ -428,8 +428,6 @@ export_filename = Path.join(System.fetch_env!("HOME"), "Desktop/double_mark.dat"
   actor_target_params,
   critic_params,
   critic_target_params,
-  experience_replay_buffer_index,
-  persisted_experience_replay_buffer_entries,
   experience_replay_buffer,
   total_episodes,
   performance_memory
@@ -445,18 +443,15 @@ export_filename = Path.join(System.fetch_env!("HOME"), "Desktop/double_mark.dat"
       actor_target_params: actor_target_params,
       critic_params: critic_params,
       critic_target_params: critic_target_params,
-      experience_replay_buffer_index: experience_replay_buffer_index,
-      persisted_experience_replay_buffer_entries: persisted_experience_replay_buffer_entries,
       experience_replay_buffer: exp_replay_buffer,
       performance_memory: performance_memory
     } = Nx.deserialize(serialized)
 
-    {actor_params, actor_target_params, critic_params, critic_target_params,
-     experience_replay_buffer_index, persisted_experience_replay_buffer_entries,
-     exp_replay_buffer, total_episodes, performance_memory}
+    {actor_params, actor_target_params, critic_params, critic_target_params, exp_replay_buffer,
+     total_episodes, performance_memory}
   rescue
     _ in [File.Error, MatchError] ->
-      {%{}, %{}, %{}, %{}, 0, 0, nil, 0, nil}
+      {%{}, %{}, %{}, %{}, nil, 0, nil}
   end
 
 fields = [
@@ -569,15 +564,13 @@ state_vector_to_input_fn = fn state_vector ->
   %{"state" => state_vector}
 end
 
-# actor_params = %{}
-# actor_target_params = %{}
-# critic_params = %{}
-# critic_target_params = %{}
-# total_episodes = 0
-# experience_replay_buffer = nil
-# performance_memory = nil
-# persisted_experience_replay_buffer_entries = 0
-# experience_replay_buffer_index = 0
+actor_params = %{}
+actor_target_params = %{}
+critic_params = %{}
+critic_target_params = %{}
+total_episodes = 0
+experience_replay_buffer = nil
+performance_memory = nil
 
 IO.inspect(
   {actor_params, actor_target_params, critic_params, critic_target_params, total_episodes},
@@ -648,8 +641,6 @@ exploration_threshold = 0.005
         critic_net: critic_net,
         critic_params: critic_params,
         critic_target_params: critic_target_params,
-        persisted_experience_replay_buffer_entries: persisted_experience_replay_buffer_entries,
-        experience_replay_buffer_index: experience_replay_buffer_index,
         experience_replay_buffer: experience_replay_buffer,
         experience_replay_buffer_max_size: 250_000,
         environment_to_state_vector_fn: environment_to_state_vector_fn,
@@ -692,9 +683,7 @@ serialized =
       :actor_target_params,
       :critic_params,
       :critic_target_params,
-      :experience_replay_buffer_index,
       :experience_replay_buffer,
-      :persisted_experience_replay_buffer_entries,
       :performance_memory
     ])
   )

--- a/livebooks/double_tack.livemd
+++ b/livebooks/double_tack.livemd
@@ -9,9 +9,8 @@ Mix.install(
   ],
   config_path: Path.join(my_app_root, "config/config.exs"),
   lockfile: Path.join(my_app_root, "mix.lock"),
-  consolidate_protocols: false
-  # change to "cuda118" to use CUDA
-  # system_env: %{"XLA_TARGET" => "cuda118"}
+  consolidate_protocols: false,
+  system_env: %{"XLA_TARGET" => System.get_env("XLA_TARGET", "cpu")}
   # force: true
 )
 ```
@@ -430,7 +429,8 @@ export_filename = Path.join(System.fetch_env!("HOME"), "Desktop/double_mark.dat"
   critic_target_params,
   experience_replay_buffer,
   total_episodes,
-  performance_memory
+  performance_memory,
+  state_features_memory
 } =
   try do
     contents = File.read!(filename)
@@ -444,14 +444,15 @@ export_filename = Path.join(System.fetch_env!("HOME"), "Desktop/double_mark.dat"
       critic_params: critic_params,
       critic_target_params: critic_target_params,
       experience_replay_buffer: exp_replay_buffer,
-      performance_memory: performance_memory
+      performance_memory: performance_memory,
+      state_features_memory: state_features_memory
     } = Nx.deserialize(serialized)
 
     {actor_params, actor_target_params, critic_params, critic_target_params, exp_replay_buffer,
-     total_episodes, performance_memory}
+     total_episodes, performance_memory, state_features_memory}
   rescue
     _ in [File.Error, MatchError] ->
-      {%{}, %{}, %{}, %{}, nil, 0, nil}
+      {%{}, %{}, %{}, %{}, nil, 0, nil, nil}
   end
 
 fields = [
@@ -466,9 +467,10 @@ fields = [
 ]
 
 num_actions = BoatLearner.Environments.DoubleTack.num_actions()
-num_observations = length(fields)
+state_features_size = length(fields)
+state_features_memory_length = 1
 
-state_input = Axon.input("state", shape: {nil, num_observations})
+state_input = Axon.input("state", shape: {nil, state_features_size})
 
 action_input = Axon.input("actions", shape: {nil, num_actions})
 
@@ -537,7 +539,7 @@ normalize_angle = fn a ->
   a / (2 * :math.pi())
 end
 
-environment_to_state_vector_fn = fn env_state ->
+environment_to_state_features_fn = fn env_state ->
   norm_x = normalize_x.(env_state.x)
   norm_y = normalize_y.(env_state.y)
 
@@ -557,11 +559,10 @@ environment_to_state_vector_fn = fn env_state ->
     env_state.has_tacked
   ]
   |> Nx.stack()
-  |> Nx.new_axis(0)
 end
 
-state_vector_to_input_fn = fn state_vector ->
-  %{"state" => state_vector}
+state_features_memory_to_input_fn = fn state_features ->
+  %{"state" => Nx.reshape(state_features, {:auto, state_features_size})}
 end
 
 actor_params = %{}
@@ -571,6 +572,7 @@ critic_target_params = %{}
 total_episodes = 0
 experience_replay_buffer = nil
 performance_memory = nil
+state_features_memory = nil
 
 IO.inspect(
   {actor_params, actor_target_params, critic_params, critic_target_params, total_episodes},
@@ -641,10 +643,13 @@ exploration_threshold = 0.005
         critic_net: critic_net,
         critic_params: critic_params,
         critic_target_params: critic_target_params,
+        state_features_memory: state_features_memory,
+        state_features_memory_length: state_features_memory_length,
         experience_replay_buffer: experience_replay_buffer,
         experience_replay_buffer_max_size: 250_000,
-        environment_to_state_vector_fn: environment_to_state_vector_fn,
-        state_vector_to_input_fn: state_vector_to_input_fn,
+        environment_to_state_features_fn: environment_to_state_features_fn,
+        state_features_memory_to_input_fn: state_features_memory_to_input_fn,
+        state_features_size: state_features_size,
         training_frequency: 32,
         batch_size: 200,
         exploration_decay_rate: exploration_decay_rate,

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,7 @@
   "kino": {:hex, :kino, "0.9.1", "4afcf036c415b1d35e5b5a25e837ab92161de1772da2d9ea61be204332a806bd", [:mix], [{:nx, "~> 0.1", [hex: :nx, repo: "hexpm", optional: true]}, {:table, "~> 0.1.2", [hex: :table, repo: "hexpm", optional: false]}], "hexpm", "0d0cff307d9c8409e19303de2801f20809153fa3e982563e90b29b171a2d8b82"},
   "kino_vega_lite": {:hex, :kino_vega_lite, "0.1.8", "ec7e97778d6b774591e4cbf7fd27850abf7c0f5e9133a3d13e069aadfa04b5e3", [:mix], [{:kino, "~> 0.7", [hex: :kino, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: false]}, {:vega_lite, "~> 0.1.4", [hex: :vega_lite, repo: "hexpm", optional: false]}], "hexpm", "0bc3135a77550ea5c5bd7bfb1fb215416ebddbbc8b1e280e6de39366cd17a2f8"},
   "nimble_options": {:hex, :nimble_options, "1.0.1", "b448018287b22584e91b5fd9c6c0ad717cb4bcdaa457957c8d57770f56625c43", [:mix], [], "hexpm", "078b2927cd9f84555be6386d56e849b0c555025ecccf7afee00ab6a9e6f63837"},
-  "nx": {:git, "https://github.com/elixir-nx/nx.git", "123137b86a59ff7927d6b0092fb119bbef2a833f", [sparse: "nx"]},
+  "nx": {:git, "https://github.com/elixir-nx/nx.git", "aab373617a3c07892590a6b9432d263f7b81b2bf", [sparse: "nx"]},
   "scholar": {:git, "https://github.com/elixir-nx/scholar.git", "d5f88914ad58f6e8359de3a323033340c213edd9", []},
   "table": {:hex, :table, "0.1.2", "87ad1125f5b70c5dea0307aa633194083eb5182ec537efc94e96af08937e14a8", [:mix], [], "hexpm", "7e99bc7efef806315c7e65640724bf165c3061cdc5d854060f74468367065029"},
   "table_rex": {:hex, :table_rex, "3.1.1", "0c67164d1714b5e806d5067c1e96ff098ba7ae79413cc075973e17c38a587caa", [:mix], [], "hexpm", "678a23aba4d670419c23c17790f9dcd635a4a89022040df7d5d772cb21012490"},

--- a/test/reinforcement_learning/utils/circular_buffer_test.exs
+++ b/test/reinforcement_learning/utils/circular_buffer_test.exs
@@ -1,0 +1,71 @@
+defmodule ReinforcementLearning.Utils.CircularBufferTest do
+  use ExUnit.Case
+
+  alias ReinforcementLearning.Utils.CircularBuffer
+
+  test "persists data and reorders correctly" do
+    Nx.default_backend(Nx.BinaryBackend)
+    Nx.Defn.default_options(compiler: Nx.Defn.Evaluator)
+
+    buffer = CircularBuffer.new({3, 2}, init_value: 0, type: :s64)
+
+    assert %CircularBuffer{size: size, index: index, data: data} =
+             buffer = CircularBuffer.append(buffer, Nx.tensor([0, 1]))
+
+    assert size == Nx.tensor(1)
+    assert index == Nx.tensor(1)
+
+    assert data ==
+             Nx.tensor([
+               [0, 1],
+               [0, 0],
+               [0, 0]
+             ])
+
+    assert %CircularBuffer{size: size, index: index, data: data} =
+             buffer = CircularBuffer.append(buffer, Nx.tensor([2, 3]))
+
+    assert size == Nx.tensor(2)
+    assert index == Nx.tensor(2)
+
+    assert data ==
+             Nx.tensor([
+               [0, 1],
+               [2, 3],
+               [0, 0]
+             ])
+
+    assert %CircularBuffer{size: size, index: index, data: data} =
+             buffer = CircularBuffer.append(buffer, Nx.tensor([4, 5]))
+
+    assert size == Nx.tensor(3)
+    assert index == Nx.tensor(0)
+
+    assert data ==
+             Nx.tensor([
+               [0, 1],
+               [2, 3],
+               [4, 5]
+             ])
+
+    assert %CircularBuffer{size: size, index: index, data: data} =
+             buffer = CircularBuffer.append(buffer, Nx.tensor([6, 7]))
+
+    assert size == Nx.tensor(3)
+    assert index == Nx.tensor(1)
+
+    assert data ==
+             Nx.tensor([
+               [6, 7],
+               [2, 3],
+               [4, 5]
+             ])
+
+    assert CircularBuffer.ordered_data(buffer) ==
+             Nx.tensor([
+               [2, 3],
+               [4, 5],
+               [6, 7]
+             ])
+  end
+end

--- a/test/reinforcement_learning/utils/noise/ou_process_test.exs
+++ b/test/reinforcement_learning/utils/noise/ou_process_test.exs
@@ -4,31 +4,35 @@ defmodule ReinforcementLearning.Utils.Noise.OUProcessTest do
   alias ReinforcementLearning.Utils.Noise.OUProcess
 
   test "generates samples with given shape" do
+    Nx.Defn.default_options(compiler: Nx.Defn.Evaluator)
+    Nx.default_backend(Nx.BinaryBackend)
+
     key = Nx.Random.key(1)
 
-    state = OUProcess.init(2)
+    state = OUProcess.init({2})
     range = 1..10
 
     {values, _key} =
       Enum.map_reduce(range, {key, state}, fn _, {prev_key, state} ->
         {state, key} = OUProcess.sample(prev_key, state)
 
-        refute Nx.backend_copy(key) == Nx.backend_copy(prev_key)
+        assert key.data.__struct__ == Nx.BinaryBackend
+        refute key == prev_key
 
         {state.x, {key, state}}
       end)
 
-    assert Enum.map(values, &Nx.backend_copy/1) == [
-             Nx.tensor([-0.161521315574646, -0.04836982861161232], backend: Nx.BinaryBackend),
-             Nx.tensor([-0.02224855124950409, -0.040264032781124115], backend: Nx.BinaryBackend),
-             Nx.tensor([-0.09898111969232559, 0.007571592926979065], backend: Nx.BinaryBackend),
-             Nx.tensor([0.2752320468425751, 0.27117180824279785], backend: Nx.BinaryBackend),
-             Nx.tensor([0.19806110858917236, 0.374011367559433], backend: Nx.BinaryBackend),
-             Nx.tensor([0.33261623978614807, 0.45093613862991333], backend: Nx.BinaryBackend),
-             Nx.tensor([0.5560829043388367, 0.3771272897720337], backend: Nx.BinaryBackend),
-             Nx.tensor([0.418714702129364, 0.24803754687309265], backend: Nx.BinaryBackend),
-             Nx.tensor([0.043423742055892944, 0.10074643790721893], backend: Nx.BinaryBackend),
-             Nx.tensor([-0.3225523829460144, 0.020469389855861664], backend: Nx.BinaryBackend)
+    assert values == [
+             Nx.tensor([-0.161521315574646, -0.04836982488632202]),
+             Nx.tensor([-0.022248566150665283, -0.040264029055833817]),
+             Nx.tensor([-0.09898112714290619, 0.007571600377559662]),
+             Nx.tensor([0.2752320170402527, 0.27117177844047546]),
+             Nx.tensor([0.19806107878684998, 0.3740113377571106]),
+             Nx.tensor([0.3326162099838257, 0.45093610882759094]),
+             Nx.tensor([0.5560828447341919, 0.3771272897720337]),
+             Nx.tensor([0.41871464252471924, 0.24803756177425385]),
+             Nx.tensor([0.04342368245124817, 0.10074643790721893]),
+             Nx.tensor([-0.3225524425506592, 0.020469389855861664])
            ]
   end
 end


### PR DESCRIPTION
This will enable the usage of RNNs in a future iteration
of the model.

Also refactors the performance_memory and the experience_replay_buffer to use the new CircularBuffer utility